### PR TITLE
refactor(logging): change category name Microsoft.DurableTask to Dapr.DurableTask

### DIFF
--- a/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
+++ b/src/Worker/Core/Shims/TaskOrchestrationContextWrapper.cs
@@ -60,7 +60,7 @@ sealed partial class TaskOrchestrationContextWrapper : TaskOrchestrationContext
         this.invocationContext = Check.NotNull(invocationContext);
         this.Properties = Check.NotNull(properties);
 
-        this.logger = this.CreateReplaySafeLogger("Microsoft.DurableTask");
+        this.logger = this.CreateReplaySafeLogger("Dapr.DurableTask");
         this.deserializedInput = deserializedInput;
     }
 

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -40,7 +40,7 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
         this.workerOptions = Check.NotNull(workerOptions).Get(name);
         this.services = Check.NotNull(services);
         this.loggerFactory = Check.NotNull(loggerFactory);
-        this.logger = loggerFactory.CreateLogger("Microsoft.DurableTask"); // TODO: use better category name.
+        this.logger = loggerFactory.CreateLogger("Dapr.DurableTask");
     }
 
     /// <inheritdoc />

--- a/test/Grpc.IntegrationTests/IntegrationTestBase.cs
+++ b/test/Grpc.IntegrationTests/IntegrationTestBase.cs
@@ -84,7 +84,7 @@ public class IntegrationTestBase : IClassFixture<GrpcSidecarFixture>, IDisposabl
     protected IReadOnlyCollection<LogEntry> GetLogs()
     {
         // NOTE: Renaming the log category is a breaking change!
-        const string ExpectedCategoryName = "Microsoft.DurableTask";
+        const string ExpectedCategoryName = "Dapr.DurableTask";
         bool foundCategory = this.logProvider.TryGetLogs(ExpectedCategoryName, out IReadOnlyCollection<LogEntry> logs);
         Assert.True(foundCategory);
         return logs;


### PR DESCRIPTION
### Description
This pull request updates the logging category/module name used in .NET logging from `Microsoft.DurableTask` to `Dapr.DurableTask`. This change reflects the transition to a Dapr-maintained fork of the original Microsoft Durable Task library.

### Motivation
Dapr has forked Microsoft.DurableTask to introduce customizations and enhancements specific to the Dapr ecosystem. To ensure accurate logging, observability, and filtering, it's important that log entries are correctly attributed to the new module name `Dapr.DurableTask` rather than the original one.

### Impact
This change is purely internal and affects only the logging metadata. There is no functional impact on runtime behavior, but log management tools and filters relying on the old category name may need to be updated.