### PR TITLE
Retry policy changes

### DIFF
--- a/src/Abstractions/Internal/IOrchestrationSubmitter.cs
+++ b/src/Abstractions/Internal/IOrchestrationSubmitter.cs
@@ -28,7 +28,7 @@ public interface IOrchestrationSubmitter
     /// <param name="input">
     /// The optional input to pass to the scheduled orchestration instance. This must be a serializable value.
     /// </param>
-    /// <param name="options">The options to start the new orchestration with.</param>
+    /// <param name="orchestrationOptions">The options to start the new orchestration with.</param>
     /// <param name="cancellation">
     /// The cancellation token. This only cancels enqueueing the new orchestration to the backend. Does not cancel the
     /// orchestration once enqueued.
@@ -36,11 +36,11 @@ public interface IOrchestrationSubmitter
     /// <returns>
     /// A task that completes when the orchestration instance is successfully scheduled. The value of this task is
     /// the instance ID of the scheduled orchestration instance. If a non-null instance ID was provided via
-    /// <paramref name="options" />, the same value will be returned by the completed task.
+    /// <paramref name="orchestrationOptions" />, the same value will be returned by the completed task.
     /// </returns>
     Task<string> ScheduleNewOrchestrationInstanceAsync(
         TaskName orchestratorName,
         object? input = null,
-        StartOrchestrationOptions? options = null,
+        StartOrchestrationOptions? orchestrationOptions = null,
         CancellationToken cancellation = default);
 }

--- a/src/Client/Core/DurableTaskClient.cs
+++ b/src/Client/Core/DurableTaskClient.cs
@@ -72,7 +72,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </summary>
     /// <remarks>
     /// <para>All orchestrations must have a unique instance ID. You can provide an instance ID using the
-    /// <paramref name="options"/> parameter or you can omit this and a random instance ID will be
+    /// <paramref name="orchestrationOptions"/> parameter or you can omit this and a random instance ID will be
     /// generated for you automatically. If an orchestration with the specified instance ID already exists and is in a
     /// non-terminal state (Pending, Running, etc.), then this operation may fail silently. However, if an orchestration
     /// instance with this ID already exists in a terminal state (Completed, Terminated, Failed, etc.) then the instance
@@ -82,7 +82,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <see cref="OrchestrationRuntimeStatus.Pending"/> state and will transition to the
     /// <see cref="OrchestrationRuntimeStatus.Running"/> after successfully awaiting its first task. The exact time it
     /// takes before a scheduled orchestration starts running depends on several factors, including the configuration
-    /// and health of the backend task hub, and whether a start time was provided via <paramref name="options" />.
+    /// and health of the backend task hub, and whether a start time was provided via <paramref name="orchestrationOptions" />.
     /// </para><para>
     /// The task associated with this method completes after the orchestration instance was successfully scheduled. You
     /// can use the <see cref="GetInstanceAsync(string, bool, CancellationToken)"/> to query the status of the
@@ -96,7 +96,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <param name="input">
     /// The optional input to pass to the scheduled orchestration instance. This must be a serializable value.
     /// </param>
-    /// <param name="options">The options to start the new orchestration with.</param>
+    /// <param name="orchestrationOptions">The options to start the new orchestration with.</param>
     /// <param name="cancellation">
     /// The cancellation token. This only cancels enqueueing the new orchestration to the backend. Does not cancel the
     /// orchestration once enqueued.
@@ -104,13 +104,13 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// <returns>
     /// A task that completes when the orchestration instance is successfully scheduled. The value of this task is
     /// the instance ID of the scheduled orchestration instance. If a non-null instance ID was provided via
-    /// <paramref name="options" />, the same value will be returned by the completed task.
+    /// <paramref name="orchestrationOptions" />, the same value will be returned by the completed task.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="orchestratorName"/> is empty.</exception>
     public abstract Task<string> ScheduleNewOrchestrationInstanceAsync(
         TaskName orchestratorName,
         object? input = null,
-        StartOrchestrationOptions? options = null,
+        StartOrchestrationOptions? orchestrationOptions = null,
         CancellationToken cancellation = default);
 
     /// <inheritdoc cref="RaiseEventAsync(string, string, object, CancellationToken)"/>
@@ -247,13 +247,13 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </para>
     /// </remarks>
     /// <param name="instanceId">The ID of the orchestration instance to terminate.</param>
-    /// <param name="options">The optional options for terminating the orchestration.</param>
+    /// <param name="instanceOptions">The optional options for terminating the orchestration.</param>
     /// <param name="cancellation">
     /// The cancellation token. This only cancels enqueueing the termination request to the backend. Does not abort
     /// termination of the orchestration once enqueued.
     /// </param>
     /// <returns>A task that completes when the terminate message is enqueued.</returns>
-    public virtual Task TerminateInstanceAsync(string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
+    public virtual Task TerminateInstanceAsync(string instanceId, TerminateInstanceOptions? instanceOptions = null, CancellationToken cancellation = default)
         => throw new NotSupportedException($"{this.GetType()} does not support orchestration termination.");
 
     /// <inheritdoc cref="SuspendInstanceAsync(string, string, CancellationToken)"/>
@@ -362,7 +362,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// </para>
     /// </remarks>
     /// <param name="instanceId">The unique ID of the orchestration instance to purge.</param>
-    /// <param name="options">The optional options for purging the orchestration.</param>
+    /// <param name="instanceOptions">The optional options for purging the orchestration.</param>
     /// <param name="cancellation">
     /// A <see cref="CancellationToken"/> that can be used to cancel the purge operation.
     /// </param>
@@ -372,7 +372,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// including the count of sub-orchestrations purged if any.
     /// </returns>
     public virtual Task<PurgeResult> PurgeInstanceAsync(
-        string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
+        string instanceId, PurgeInstanceOptions? instanceOptions = null, CancellationToken cancellation = default)
     {
         throw new NotSupportedException($"{this.GetType()} does not support purging of orchestration instances.");
     }
@@ -385,7 +385,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// Purges orchestration instances metadata from the durable store.
     /// </summary>
     /// <param name="filter">The filter for which orchestrations to purge.</param>
-    /// <param name="options">The optional options for purging the orchestration.</param>
+    /// <param name="purgeOptions">The optional options for purging the orchestration.</param>
     /// <param name="cancellation">
     /// A <see cref="CancellationToken"/> that can be used to cancel the purge operation.
     /// </param>
@@ -395,7 +395,7 @@ public abstract class DurableTaskClient : IOrchestrationSubmitter, IAsyncDisposa
     /// including the count of sub-orchestrations purged if any.
     /// </returns>
     public virtual Task<PurgeResult> PurgeAllInstancesAsync(
-        PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
+        PurgeInstancesFilter filter, PurgeInstanceOptions? purgeOptions = null, CancellationToken cancellation = default)
     {
         throw new NotSupportedException($"{this.GetType()} does not support purging of orchestration instances.");
     }

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -3,15 +3,14 @@
 
 using System.Diagnostics;
 using System.Text;
-using DurableTask.Core.Serializing;
-using Google.Protobuf.WellKnownTypes;
 using Dapr.DurableTask.Client.Entities;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Net.Client.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using static Dapr.DurableTask.Protobuf.TaskHubSidecarService;
 using P = Dapr.DurableTask.Protobuf;
-using TaskName = Dapr.DurableTask.TaskName;
 
 namespace Dapr.DurableTask.Client.Grpc;
 

--- a/src/Client/Grpc/GrpcDurableTaskClient.cs
+++ b/src/Client/Grpc/GrpcDurableTaskClient.cs
@@ -426,7 +426,6 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
         return new AsyncDisposable(() => new(c.ShutdownAsync()));
     }
 
-#if NET6_0_OR_GREATER
     static GrpcChannel GetChannel(string? address)
     {
         if (string.IsNullOrEmpty(address))
@@ -436,19 +435,6 @@ public sealed class GrpcDurableTaskClient : DurableTaskClient
 
         return GrpcChannel.ForAddress(address);
     }
-#endif
-
-#if NETSTANDARD2_0
-    static GrpcChannel GetChannel(string? address)
-    {
-        if (string.IsNullOrEmpty(address))
-        {
-            address = "localhost:4001";
-        }
-
-        return new(address, ChannelCredentials.Insecure);
-    }
-#endif
 
     async Task<PurgeResult> PurgeInstancesCoreAsync(
         P.PurgeInstancesRequest request, CancellationToken cancellation = default)

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Dapr.DurableTask.Worker.Hosting;
+using Grpc.Net.Client.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/src/Worker/Grpc/GrpcDurableTaskWorker.cs
+++ b/src/Worker/Grpc/GrpcDurableTaskWorker.cs
@@ -93,6 +93,23 @@ sealed partial class GrpcDurableTaskWorker : DurableTaskWorker
             HttpClient = httpClient,
             MaxReceiveMessageSize = null, // No message size limit
             DisposeHttpClient = false, // Lifetime managed by the HttpClientFactory
+            ServiceConfig = new ServiceConfig
+            {
+                MethodConfigs =
+                {
+                    new MethodConfig
+                    {
+                        Names = { MethodName.Default },
+                        RetryPolicy = new global::Grpc.Net.Client.Configuration.RetryPolicy
+                        {
+                            MaxAttempts = 5,
+                            MaxBackoff = TimeSpan.FromSeconds(12),
+                            BackoffMultiplier = 1.25,
+                            InitialBackoff = TimeSpan.FromSeconds(2),
+                        },
+                    },
+                },
+            },
         });
     }
 

--- a/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DefaultDurableTaskClientBuilderTests.cs
@@ -89,13 +89,13 @@ public class DefaultDurableTaskClientBuilderTests
         }
 
         public override Task<PurgeResult> PurgeInstanceAsync(
-            string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
+            string instanceId, PurgeInstanceOptions? instanceOptions = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<PurgeResult> PurgeAllInstancesAsync(
-            PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
+            PurgeInstancesFilter filter, PurgeInstanceOptions? purgeOptions = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
@@ -115,7 +115,7 @@ public class DefaultDurableTaskClientBuilderTests
         public override Task<string> ScheduleNewOrchestrationInstanceAsync(
             TaskName orchestratorName,
             object? input = null,
-            StartOrchestrationOptions? options = null,
+            StartOrchestrationOptions? orchestrationOptions = null,
             CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
@@ -128,7 +128,7 @@ public class DefaultDurableTaskClientBuilderTests
         }
 
         public override Task TerminateInstanceAsync(
-            string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
+            string instanceId, TerminateInstanceOptions? instanceOptions = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }

--- a/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
+++ b/test/Client/Core.Tests/DependencyInjection/DurableTaskClientBuilderExtensionsTests.cs
@@ -119,13 +119,13 @@ public class DurableTaskClientBuilderExtensionsTests
         }
 
         public override Task<PurgeResult> PurgeInstanceAsync(
-            string instanceId, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
+            string instanceId, PurgeInstanceOptions? instanceOptions = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
 
         public override Task<PurgeResult> PurgeAllInstancesAsync(
-            PurgeInstancesFilter filter, PurgeInstanceOptions? options = null, CancellationToken cancellation = default)
+            PurgeInstancesFilter filter, PurgeInstanceOptions? purgeOptions = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }
@@ -145,7 +145,7 @@ public class DurableTaskClientBuilderExtensionsTests
         public override Task<string> ScheduleNewOrchestrationInstanceAsync(
             TaskName orchestratorName,
             object? input = null,
-            StartOrchestrationOptions? options = null,
+            StartOrchestrationOptions? orchestrationOptions = null,
             CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
@@ -158,7 +158,7 @@ public class DurableTaskClientBuilderExtensionsTests
         }
 
         public override Task TerminateInstanceAsync(
-            string instanceId, TerminateInstanceOptions? options = null, CancellationToken cancellation = default)
+            string instanceId, TerminateInstanceOptions? instanceOptions = null, CancellationToken cancellation = default)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
- Removed the 100 second timeout from HttpClient used by the DurableTaskClient
- Assigned keep-alive policy to DurableTaskClient equivalent to policy used in GrpcDurableTaskWorker
- Added retry policy to both gRPC client initializations to support up to 5 retry operations in case of transient failure with backoff