### PR TITLE
Suppress extraneous logging by default

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.8" />

--- a/src/Client/Core/Client.csproj
+++ b/src/Client/Core/Client.csproj
@@ -9,6 +9,7 @@ The client is responsible for interacting with orchestrations from outside the w
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 

--- a/src/Client/Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Client/Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using DurableTask.Core.Serializing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Dapr.DurableTask.Client;
@@ -91,6 +91,22 @@ public static class ServiceCollectionExtensions
                 }
             });
 
+        services.Configure<LoggerFilterOptions>(options =>
+        {
+            // Suppress verbose HttpClient logging
+            options.Rules.Add(new LoggerFilterRule(null, "System.Net.Http.HttpClient", LogLevel.Warning, null));
+            options.Rules.Add(new LoggerFilterRule(null, "Microsoft.Extensions.Http", LogLevel.Warning, null));
+
+            // Suppress noisy gRPC logging
+            options.Rules.Add(new LoggerFilterRule(null, "Grpc.Net.Client", LogLevel.Warning, null));
+            options.Rules.Add(new LoggerFilterRule(null, "Grpc.Core", LogLevel.Warning, null));
+            options.Rules.Add(new LoggerFilterRule(null, "Grpc.AspNetCore.Server", LogLevel.Warning, null));
+
+            // Suppress other noisy infrastructure
+            options.Rules.Add(new LoggerFilterRule(null, "System.Net.Http.SocketsHttpHandler", LogLevel.Warning, null));
+            options.Rules.Add(new LoggerFilterRule(null, "System.Net.NameResolution", LogLevel.Warning, null));
+        });
+
         return services;
     }
 
@@ -98,7 +114,7 @@ public static class ServiceCollectionExtensions
     {
         // To ensure the builders are tracked with this service collection, we use a singleton service descriptor as a
         // holder for all builders.
-        ServiceDescriptor descriptor = services.FirstOrDefault(sd => sd.ServiceType == typeof(BuilderContainer));
+        ServiceDescriptor? descriptor = services.FirstOrDefault(sd => sd.ServiceType == typeof(BuilderContainer));
 
         if (descriptor is null)
         {

--- a/src/Worker/Core/Worker.csproj
+++ b/src/Worker/Core/Worker.csproj
@@ -10,6 +10,7 @@ The worker is responsible for processing durable task work items.</PackageDescri
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>


### PR DESCRIPTION
Added configuration to worker and client packages to suppress System.Net.Http.HttpClient methods